### PR TITLE
Update postcss-jsx from 0.10.x to 0.25.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"version": "7.0.0-beta.47",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.47.tgz",
 			"integrity": "sha512-W7IeG4MoVf4oUvWfHUx9VG9if3E0xSUDf1urrnNYtC2ow1dz2ptvQ6YsJfyVXDuPTFXz66jkHhzMW7a5Eld7TA==",
+			"dev": true,
 			"requires": {
 				"@babel/highlight": "7.0.0-beta.47"
 			}
@@ -16,6 +17,7 @@
 			"version": "7.0.0-beta.47",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.47.tgz",
 			"integrity": "sha512-fJP+9X+gqgTTZzTqrKJHwebPwt6S/e/4YuyRyKyWHAIirGgUwjRoZgbFci24wwGYMJW7nlkCSwWG7QvCVsG0eg==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "7.0.0-beta.47",
 				"jsesc": "^2.5.1",
@@ -27,7 +29,8 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				}
 			}
 		},
@@ -35,6 +38,7 @@
 			"version": "7.0.0-beta.47",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.47.tgz",
 			"integrity": "sha512-0LSvt95XCYaOrDA5K68KkTyldKXizDwBnKACdYzQszp1GdbtzmSeGwFU5Ecw86fU6bkYXtDvkFTOQwk/WQSJPw==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-get-function-arity": "7.0.0-beta.47",
 				"@babel/template": "7.0.0-beta.47",
@@ -45,6 +49,7 @@
 			"version": "7.0.0-beta.47",
 			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.47.tgz",
 			"integrity": "sha512-63j0i3YUW8CO//uQc3ACffJdIlYcIlysuHjMF0yzQhqKoQ/CUPv0hf3nBwdRGjiWrr3JcL6++NF4XmXdwSU+fA==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "7.0.0-beta.47"
 			}
@@ -53,6 +58,7 @@
 			"version": "7.0.0-beta.47",
 			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.47.tgz",
 			"integrity": "sha512-jx8GmxryT6Qy4+24W6M6TnVL9T8bxqdyg5UKHjxBdw0Y2Sano1n0WphUS2seuOugn04W2ZQLqGc0ut8nGe/taA==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "7.0.0-beta.47"
 			}
@@ -61,16 +67,23 @@
 			"version": "7.0.0-beta.47",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.47.tgz",
 			"integrity": "sha512-d505K3Hth1eg0b2swfEF7oFMw3J9M8ceFg0s6dhCSxOOF+07WDvJ0HKT/YbK/Jk9wn8Wyr6HIRAUPKJ9Wfv8Rg==",
+			"dev": true,
 			"requires": {
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
 				"js-tokens": "^3.0.0"
 			}
 		},
+		"@babel/parser": {
+			"version": "7.0.0-beta.48",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.48.tgz",
+			"integrity": "sha512-X3pKxvy7vL79zc/6XS6cCObyuRMnsRGRu7d3zVSPZGCdxkK0/wTeFRwseRjcvhReV/6LW2D8H8qHVFFL0c+5+w=="
+		},
 		"@babel/template": {
 			"version": "7.0.0-beta.47",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.47.tgz",
 			"integrity": "sha512-mAzrOCLwOb4jAobHi0kTwIkoamP1Do28c6zxvrDXjYSJFZHz6KGuzMaT0AV7ZCq7M3si7QypVVMVX2bE6IsuOg==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0-beta.47",
 				"@babel/types": "7.0.0-beta.47",
@@ -81,7 +94,8 @@
 				"babylon": {
 					"version": "7.0.0-beta.47",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-					"integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
+					"integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ==",
+					"dev": true
 				}
 			}
 		},
@@ -89,6 +103,7 @@
 			"version": "7.0.0-beta.47",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.47.tgz",
 			"integrity": "sha512-kYGGs//OnUnei+9TTldxlgf7llprj7VUeDKtG50+g+0k1g0yZyrkEgbyFheYFdnudR8IDEHOEXVsUuY82r5Aiw==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.0.0-beta.47",
 				"@babel/generator": "7.0.0-beta.47",
@@ -105,7 +120,8 @@
 				"babylon": {
 					"version": "7.0.0-beta.47",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-					"integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
+					"integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ==",
+					"dev": true
 				}
 			}
 		},
@@ -113,6 +129,7 @@
 			"version": "7.0.0-beta.47",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.47.tgz",
 			"integrity": "sha512-MOP5pOosg7JETrVGg8OQyzmUmbyoSopT5j2HlblHsto89mPz3cmxzn1IA4UNUmnWKgeticSwfhS+Gdy25IIlBQ==",
+			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
 				"lodash": "^4.17.5",
@@ -5477,21 +5494,129 @@
 			}
 		},
 		"postcss-jsx": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.24.0.tgz",
-			"integrity": "sha1-yPbYJyAS7sx2YllXq0sqgV8WziM=",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.25.0.tgz",
+			"integrity": "sha512-0eN3ca+dPntRBiDNs5dk8r5HNTaHA+iYriRv0yPH68TbAxXqTprGoWmFfqJTa/Zp8EYlt2qCl+a9AXE+LPBD9w==",
 			"requires": {
-				"@babel/generator": "^7.0.0-beta.47",
-				"@babel/traverse": "^7.0.0-beta.47",
-				"@babel/types": "^7.0.0-beta.47",
-				"babylon": "^7.0.0-beta.47",
-				"postcss-styled": ">=0.24.0"
+				"@babel/generator": "^7.0.0-beta.48",
+				"@babel/parser": "^7.0.0-beta.48",
+				"@babel/traverse": "^7.0.0-beta.48",
+				"@babel/types": "^7.0.0-beta.48",
+				"postcss-styled": ">=0.25.0"
 			},
 			"dependencies": {
-				"babylon": {
-					"version": "7.0.0-beta.47",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-					"integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.49",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.49.tgz",
+					"integrity": "sha1-vs2AVIJzREDJ0TfkbXc0DmTX9Rs=",
+					"requires": {
+						"@babel/highlight": "7.0.0-beta.49"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.0.0-beta.49",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.49.tgz",
+					"integrity": "sha1-6c/9qROZaszseTu8JauRvBnQv3o=",
+					"requires": {
+						"@babel/types": "7.0.0-beta.49",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.5",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.0.0-beta.49",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.49.tgz",
+					"integrity": "sha1-olwRGbnwNSeGcBJuAiXAMEHI3jI=",
+					"requires": {
+						"@babel/helper-get-function-arity": "7.0.0-beta.49",
+						"@babel/template": "7.0.0-beta.49",
+						"@babel/types": "7.0.0-beta.49"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0-beta.49",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.49.tgz",
+					"integrity": "sha1-z1Aj8y0q2S0Ic3STnOwJUby1FEE=",
+					"requires": {
+						"@babel/types": "7.0.0-beta.49"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.0.0-beta.49",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.49.tgz",
+					"integrity": "sha1-QNeO2glo0BGxxShm5XRs+yPldUg=",
+					"requires": {
+						"@babel/types": "7.0.0-beta.49"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0-beta.49",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.49.tgz",
+					"integrity": "sha1-lr3GtD4TSCASumaRsQGEktOWIsw=",
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.0"
+					}
+				},
+				"@babel/template": {
+					"version": "7.0.0-beta.49",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.49.tgz",
+					"integrity": "sha1-44q+ghfLl5P0YaUwbXrXRdg+HSc=",
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.49",
+						"@babel/parser": "7.0.0-beta.49",
+						"@babel/types": "7.0.0-beta.49",
+						"lodash": "^4.17.5"
+					},
+					"dependencies": {
+						"@babel/parser": {
+							"version": "7.0.0-beta.49",
+							"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.49.tgz",
+							"integrity": "sha1-lE0MW6KBK7FZ7b0iZ0Ov0mUXm9w="
+						}
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.0.0-beta.49",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.49.tgz",
+					"integrity": "sha1-TypzaCoYM07WYl0QCo0nMZ98LWg=",
+					"requires": {
+						"@babel/code-frame": "7.0.0-beta.49",
+						"@babel/generator": "7.0.0-beta.49",
+						"@babel/helper-function-name": "7.0.0-beta.49",
+						"@babel/helper-split-export-declaration": "7.0.0-beta.49",
+						"@babel/parser": "7.0.0-beta.49",
+						"@babel/types": "7.0.0-beta.49",
+						"debug": "^3.1.0",
+						"globals": "^11.1.0",
+						"invariant": "^2.2.0",
+						"lodash": "^4.17.5"
+					},
+					"dependencies": {
+						"@babel/parser": {
+							"version": "7.0.0-beta.49",
+							"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.49.tgz",
+							"integrity": "sha1-lE0MW6KBK7FZ7b0iZ0Ov0mUXm9w="
+						}
+					}
+				},
+				"@babel/types": {
+					"version": "7.0.0-beta.49",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.49.tgz",
+					"integrity": "sha1-t+Oxw/TUz+Eb34yJ8e/V4WF7h6Y=",
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.5",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
@@ -5624,9 +5749,9 @@
 			}
 		},
 		"postcss-styled": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/postcss-styled/-/postcss-styled-0.24.0.tgz",
-			"integrity": "sha1-zJ8UIgIrGsuPdDr7GZLxPwKKRsw="
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/postcss-styled/-/postcss-styled-0.25.0.tgz",
+			"integrity": "sha512-xnQ1YL87wqyaYptBoCmvOl8cWeHvJ7uoW9unEDO32m4JuuBwpc6S1K9zqaM65TI1ur8j+yFdA9QH7ihxQZwvww=="
 		},
 		"postcss-syntax": {
 			"version": "0.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5477,15 +5477,15 @@
 			}
 		},
 		"postcss-jsx": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.10.0.tgz",
-			"integrity": "sha1-rIXqRxDBLz0/brVqRBl1IX3NzhM=",
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.24.0.tgz",
+			"integrity": "sha1-yPbYJyAS7sx2YllXq0sqgV8WziM=",
 			"requires": {
 				"@babel/generator": "^7.0.0-beta.47",
 				"@babel/traverse": "^7.0.0-beta.47",
 				"@babel/types": "^7.0.0-beta.47",
 				"babylon": "^7.0.0-beta.47",
-				"postcss-styled": "^0.10.0"
+				"postcss-styled": ">=0.24.0"
 			},
 			"dependencies": {
 				"babylon": {
@@ -5624,9 +5624,9 @@
 			}
 		},
 		"postcss-styled": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/postcss-styled/-/postcss-styled-0.10.0.tgz",
-			"integrity": "sha1-N6vilX4EfSyhnVdaMWjAR3VxjLw="
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/postcss-styled/-/postcss-styled-0.24.0.tgz",
+			"integrity": "sha1-zJ8UIgIrGsuPdDr7GZLxPwKKRsw="
 		},
 		"postcss-syntax": {
 			"version": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"array-to-error": "^1.1.1",
 		"inspect-with-kind": "^1.0.4",
 		"lodash": "^4.17.5",
-		"postcss-jsx": "^0.10.0",
+		"postcss-jsx": "^0.24.0",
 		"stylelint": "github:stylelint/stylelint#ecd7c0a89ef3d0c164770883852b3574a013144e",
 		"stylelint-warning-to-vscode-diagnostic": "^1.0.1"
 	},

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"array-to-error": "^1.1.1",
 		"inspect-with-kind": "^1.0.4",
 		"lodash": "^4.17.5",
-		"postcss-jsx": "^0.24.0",
+		"postcss-jsx": "^0.25.0",
 		"stylelint": "github:stylelint/stylelint#ecd7c0a89ef3d0c164770883852b3574a013144e",
 		"stylelint-warning-to-vscode-diagnostic": "^1.0.1"
 	},


### PR DESCRIPTION
This updates the `postcss-jsx` dependency to the latest release 0.24.0: https://github.com/gucong3000/postcss-jsx/releases/tag/v0.24.0

Fixes: https://github.com/shinnn/vscode-stylelint/issues/188